### PR TITLE
Actualizado requirements.txt para incluir Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests==2.18.4
 django-filter==1.1.0
 psycopg2==2.7.4
 django-rest-swagger==2.2.0
+Pillow==5.3.0


### PR DESCRIPTION
Se ha actualizado el fichero requirements.txt para incluir Pillow (necesario por Django para trabajar con el ImageField), ya que Travis CI no compilaba al no poder usar el ImageField. Por tanto, esto soluciona el bug de la incidencia 20 (fixed #20 ), una vez que todo el mundo vuelva a ejecutar el "pip install -r requirements.txt" y compile Travis CI.