### PR TITLE
Solución a autenticación en panel de administración de django

### DIFF
--- a/decide/authentication/views.py
+++ b/decide/authentication/views.py
@@ -55,9 +55,9 @@ class SignUpView(TemplateView):
 
 class SaveUserView(APIView):
     def post(self, request):
-        username = request.data.get('username')
+        email = request.data.get('email')
         password = request.data.get('password')
-        User.objects.create_user(username,None, password)
+        User.objects.create_user(email, password)
 
         return Response({})
 
@@ -106,7 +106,7 @@ obtain_auth_token = ObtainAuthToken.as_view()
 def nuevo_usuario(request):
     if request.method == 'POST':
         formulario = UserCreateForm(request.POST)
-        if formulario.is_valid:
+        if formulario.is_valid():
             formulario.save()
             return HttpResponseRedirect('/admin')
     else:

--- a/decide/base/backends.py
+++ b/decide/base/backends.py
@@ -1,7 +1,9 @@
 from django.contrib.auth.backends import ModelBackend
 
 from base import mods
+from django.contrib.auth import get_user_model
 
+UserModel = get_user_model()
 
 class AuthBackend(ModelBackend):
     '''
@@ -13,17 +15,26 @@ class AuthBackend(ModelBackend):
     for future admin queries.
     '''
 
-    def authenticate(self, request, username=None, password=None, **kwargs):
-        u = super().authenticate(request, username=username,
-                                 password=password, **kwargs)
+    def new_authenticate(self, request, email=None, password=None, **kwargs):
+        if email is None:
+            email = kwargs.get(UserModel.EMAIL_FIELD)
+        try:
+            user = UserModel._default_manager.get_by_natural_key(email)
+        except UserModel.DoesNotExist:
+            # Run the default password hasher once to reduce the timing
+            # difference between an existing and a nonexistent user (#20760).
+            UserModel().set_password(password)
+        else:
+            if user.check_password(password) and super.user_can_authenticate(user):
+                u = user
 
-        # only doing this for the admin web interface
-        if u and request.content_type == 'application/x-www-form-urlencoded':
-            data = {
-                'username': username,
-                'password': password,
-            }
-            token = mods.post('authentication', entry_point='/login/', json=data)
-            request.session['auth-token'] = token['token']
+                # only doing this for the admin web interface
+                if u and request.content_type == 'application/x-www-form-urlencoded':
+                    data = {
+                        'email': email,
+                        'password': password,
+                    }
+                    token = mods.post('authentication', entry_point='/login/', json=data)
+                    request.session['auth-token'] = token['token']
 
-        return u
+                return u


### PR DESCRIPTION
Solucionado fixed #24 
El fallo se encontraba en backends.py del modulo "base", se utilizaba el usuario anterior sin email para generar el token.
Se ha modificado el método para generar el token con el nuevo usuario.

Adicionalmente se han corregido fallos en las vistas de autenticación.
Ahora se muestran los fallos de validación en el formulario de registro.