### PR TITLE
Añadiendo test de travis para subirlo al repositorio padre.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - python ./decide/manage.py makemigrations
   - python ./decide/manage.py migrate
 #  - python ./decide/manage.py compilemessages
-#  - python ./decide/manage.py test ./decide
+  - python ./decide/manage.py test ./decide
   - if [[ $TRAVIS_BRANCH == $RAMA_TRAVIS ]] && [[ $DEPLOY_TRAVIS == "1" ]]; then git archive --format zip --output ./$NOMBRE_ZIP.zip $RAMA_TRAVIS; echo "Zip generado correctamente."; fi
 
 before_deploy:


### PR DESCRIPTION
Los test fueron comentados para agilizar el proceso de corrección de errores en la configuración de Heroku.
Puesto que Heroku ya está funcionando, se procede a subir de nuevo el archivo travis con los test habilitados.