### PR TITLE
Traducción al catalán en despliegue de Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 % prepara el repositorio para su despliegue. 
 release: sh -c 'cd decide && python manage.py makemigrations && python manage.py migrate && echo "from django.contrib.auth import get_user_model; User = get_user_model();\nif not User.objects.filter(email='"'"'admin@decide.com'"'"').exists(): User.objects.create_superuser('"'"'admin@decide.com'"'"', '"'"'practica'"'"')" | python3 ./manage.py shell'
 % especifica el comando para lanzar Decide
-web: sh -c 'cd decide &&  python manage.py makemessages -l es && python manage.py makemessages -l ca && python manage.py compilemessages -l es && python manage.py compilemessages -l ca && gunicorn decide.wsgi --log-file -'
+web: sh -c 'cd decide &&  python manage.py makemessages -l es && python manage.py makemessages -l ca && python manage.py compilemessages && gunicorn decide.wsgi --log-file -'

--- a/decide/locale/es/LC_MESSAGES/django.po
+++ b/decide/locale/es/LC_MESSAGES/django.po
@@ -581,7 +581,7 @@ msgstr "Ir"
 
 #: visualizer/templates/visualizer/list_ended.html:72
 msgid "There are no ended votings yet"
-msgstr ""
+msgstr "Todavía no hay votaciones finalizadas"
 
 #: visualizer/templates/visualizer/not_started.html:13
 msgid "Voting not started"


### PR DESCRIPTION
### Descripción del pull request
Hemos descubierto un fallo en el archivo Procfile de nuestro repositorio.
Dicho fallo se producía al ejecutar el comando:
python manage.py compilemessages -l es
El cuál tan sólo compilaba las traducciones al español.

Para solucionarlo se ha optado por implementar, en lugar del comando anterior, el siguiente:
python manage.py compilemessages
Éste nos permite compilar todas las traducciones de todos los idiomas disponibles en la aplicación.

### Motivo del pull request
Se ha corregido un error que provocaba que las traducciones al catalán no se mostrasen correctamente.
Además se ha agregado una frase que faltaba por traducir.

### Pruebas y/o revisiones
1. Acceder a la página principal de la aplicación desplegada en Heroku.
2. Acceder a través del menú principal al registro de usuarios.
3. Cambiar de idioma al "Catalán"
4. Comprobar que los campos del formulario de registro no se traducen correctamente.

### Capturas de pantalla o códigos importantes
`python manage.py compilemessages`

### Cambios de configuración
No se han producido más cambios aparte de los ya nombrados.