### PR TITLE
Eliminación traducciones docker #86

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,9 +22,3 @@ RUN pip install -r requirements.txt
 WORKDIR /app/decide
 ADD docker-settings.py /app/decide/local_settings.py
 RUN ./manage.py collectstatic
-RUN apt-get update 
-RUN apt-get install -y gettext 
-RUN apt-get install -y libgettextpo-dev
-RUN docker-compose run --rm web django-admin makemessages -l es
-RUN docker-compose run --rm web django-admin makemessages -l ca
-RUN docker-compose run --rm web django-admin compilemessages


### PR DESCRIPTION
### Descripción del pull request
Se elimina los comandos para compilar traducciones de dockerfile.


### Motivo del pull request
Falla RUN apt-get
Los comandos funcionan correctamente si existe dominio, pero no es nuestro caso.
Estamos en una red "prestada" cin IP provisional. No tenemos dominio para nuestra localización.

### Pruebas y/o revisiones
Una vez ejecutado el script docker_remoto por ssh, debe desplegarse la aplicación.

### Capturas de pantalla o códigos importantes
![image](https://user-images.githubusercontent.com/44395689/51076662-a118a680-169b-11e9-8e3a-b8f062c600b7.png)

### Cambios de configuración
No hay
